### PR TITLE
Add support for leftid/rightid in psk configuration

### DIFF
--- a/templates/connection.secrets
+++ b/templates/connection.secrets
@@ -1,2 +1,2 @@
 #jinja2: lstrip_blocks: True
-{{ item.value.local_gateway_ip }} {{ item.value.remote_gateway_ip }}: PSK "{{ item.value.psk }}"
+{{ item.value.options.leftid | default(item.value.local_gateway_ip) }} {{ item.value.options.rightid | default(item.value.remote_gateway_ip) }}: PSK "{{ item.value.psk }}"


### PR DESCRIPTION
Connections can define a leftid and rightid attribute that is used to identify particpant during authentication. 
SEE: 
https://libreswan.org/man/ipsec.conf.5.html
https://libreswan.org/wiki/High_Availability_/_Failover_VPN_in_AWS_using_libreswan#PSK