### PR TITLE
feat: add support for ipsec connection reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ ipsec_connections:
       dpddelay: '10'
       dpdtimeout: '30'
       dpdaction: 'restart_by_peer'
+ipsec_handler: "restart ipsec service"
 ```
 
 Default installed packages can be overriden with `ipsec_required_packages`.
@@ -40,6 +41,11 @@ Default installed packages can be overriden with `ipsec_required_packages`.
 ipsec_required_packages:
   - libreswan
 ```
+
+`ipsec_handler` can be set to either `restart ipsec service` or `reload ipsec connections`:
+
+* `restart ipsec service`(default): restarts the whole ipsec service
+* `reload ipsec connections`: create or update indivual ipsec connections
 
 Dependencies
 ------------

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -5,3 +5,5 @@ ipsec_connections:
     remote_gateway_ip: ''
     psk: ''
     options: {}
+
+ipsec_handler: "restart ipsec service"

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -3,3 +3,62 @@
   ansible.builtin.service:
     name: ipsec
     state: restarted
+
+- name: register ipsec connections statuses
+  ansible.builtin.set_fact:
+    updated_ipsec_connections: "{{ ipsec_connections_creation.results
+                                    | selectattr('changed')
+                                    | map(attribute='item.key') }}"
+    updated_ipsec_secrets: "{{ ipsec_secrets_creation.results
+                                | selectattr('changed')
+                                | map(attribute='item.key') }}"
+  listen: "reload ipsec connections"
+
+- name: compute changed ipsec connections
+  ansible.builtin.set_fact:
+    changed_ipsec_connections: "{{ updated_ipsec_connections
+                                    | union(updated_ipsec_secrets) }}"
+  listen: "reload ipsec connections"
+
+- name: reread ipsec secret
+  ansible.builtin.command: ipsec auto --rereadsecrets
+  changed_when: true
+  listen: "reload ipsec connections"
+  when: not ansible_check_mode
+
+- name: reread ipsec secret (check_mode)
+  ansible.builtin.debug:
+    msg: "Without check_mode `ipsec auto --rereadsecrets` would have been triggered."
+  changed_when: true
+  listen: "reload ipsec connections"
+  when: ansible_check_mode
+
+- name: replace or create updated ipsec connection
+  ansible.builtin.command: ipsec auto --replace {{ item }}
+  changed_when: true
+  loop: "{{ changed_ipsec_connections }}"
+  listen: "reload ipsec connections"
+  when: not ansible_check_mode
+
+- name: replace or create updated ipsec connection (check_mode)
+  ansible.builtin.debug:
+    msg: "Without check_mode `ipsec auto --replace {{ item }}` would have been triggered."
+  changed_when: true
+  loop: "{{ changed_ipsec_connections }}"
+  listen: "reload ipsec connections"
+  when: ansible_check_mode
+
+- name: set ipsec connection up
+  ansible.builtin.command: ipsec auto --up {{ item }}
+  changed_when: true
+  loop: "{{ changed_ipsec_connections }}"
+  listen: "reload ipsec connections"
+  when: not ansible_check_mode
+
+- name: set ipsec connection up (check_mode)
+  ansible.builtin.debug:
+    msg: "Without check_mode `ipsec auto --up {{ item }}` would have been triggered."
+  changed_when: true
+  loop: "{{ changed_ipsec_connections }}"
+  listen: "reload ipsec connections"
+  when: ansible_check_mode

--- a/molecule/default/side_effect.yml
+++ b/molecule/default/side_effect.yml
@@ -1,0 +1,24 @@
+---
+- name: Side effect
+  hosts: all
+  become: true
+  vars:
+    ipsec_connections:
+      test-conn:
+        local_gateway_ip: '172.16.100.17'
+        remote_gateway_ip: '172.16.100.33'
+        psk: 'testpskstring'
+        options:
+          leftsubnet: '192.168.1.0/24'
+          leftsourceip: '192.168.1.1'
+          rightsubnet: '192.168.2.0/24'
+          rightsourceip: '192.168.2.1'
+          auto: 'start'
+          authby: 'secret'
+          type: 'tunnel'
+          ikelifetime: '10h'
+          ike: 'aes128-sha1;modp2048'
+          phase2alg: 'aes128-sha1;modp2048'
+    ipsec_handler: reload ipsec connections
+  roles:
+    - role: oukooveu.libreswan

--- a/tasks/configure_connections.yaml
+++ b/tasks/configure_connections.yaml
@@ -5,7 +5,8 @@
     dest: "/etc/ipsec.d/{{ item.key }}.conf"
     mode: '0644'
   loop: "{{ ipsec_connections | dict2items }}"
-  notify: restart ipsec service
+  register: ipsec_connections_creation
+  notify: "{{ ipsec_handler }}"
 
 - name: "create ipsec secrets files"
   ansible.builtin.template:
@@ -13,4 +14,5 @@
     dest: "/etc/ipsec.d/{{ item.key }}.secrets"
     mode: '0600'
   loop: "{{ ipsec_connections | dict2items }}"
-  notify: restart ipsec service
+  register: ipsec_secrets_creation
+  notify: "{{ ipsec_handler }}"


### PR DESCRIPTION
Add an optional handler that restarts ipsec connection individually instead of restarting the whole service.

This allows to add or update ipsec connection without affecting existing ones.